### PR TITLE
Update custom properties for scale configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
+[ci]: https://travis-ci.org/erikjung/postcss-modular-scale-unit
+[ci-img]: https://travis-ci.org/erikjung/postcss-modular-scale-unit.svg
+
 [PostCSS]: https://github.com/postcss/postcss
 [PostCSS usage docs]: https://github.com/postcss/postcss#usage
-[ci-img]: https://travis-ci.org/erikjung/postcss-modular-scale-unit.svg
-[ci]: https://travis-ci.org/erikjung/postcss-modular-scale-unit
+
+[modular-scale]: https://github.com/kristoferjoseph/modular-scale
 [postcss-modular-scale]: https://github.com/kristoferjoseph/postcss-modular-scale
 [postcss-vertical-rhythm]: https://github.com/markgoodyear/postcss-vertical-rhythm
 [postcss-cssnext]: https://github.com/MoOx/postcss-cssnext
@@ -9,41 +12,66 @@
 
 # PostCSS Modular Scale Unit [![Build Status][ci-img]][ci]
 
-> A [PostCSS] plugin to create a modular scale unit.
+This plugin transforms CSS declaration values using a custom `msu` unit. Instances of this unit are replaced with numbers from a [modular scale](http://modularscale.com).
 
-## Install
+## Installation
 
 ```sh
-npm install postcss-modular-scale-unit --save-dev
+npm install postcss-modular-scale-unit
 ```
 
 ## Examples
 
-**Input:**
+### Setup
+
+The **ratio** and **base** parameters of your modular scale can be supplied with the `--modular-scale` custom property. This property acts as a shorthand, accepting values in this order:
+
+
+0. **ratio:** either a decimal or fraction
+0. **base:** (optional) one or more integers, defaulting to `1` if omitted
 
 ```css
-/* Options passed to modular-scale */
 :root {
-  --msu-bases: 1;
-  --msu-ratios: 1.5;
+  /* Just a ratio of 1.5 */
+  --modular-scale: 1.5;
+
+  /* Same as above, but as a fraction */
+  --modular-scale: 3/2;
+
+  /* Ratio of 1.5 with bases of 1 and 1.25 */
+  --modular-scale: 1.5 1 1.25;
+}
+```
+
+### Input
+
+```css
+.Example {
+  line-height: 1msu;
+}
+
+.Example {
+  width: calc(-2msu * 100%);
 }
 
 .Example {
   font-size: calc(2msu * 1em);
-  line-height: 1msu;
 }
 ```
 
-**Output:**
+### Output
 
 ```css
-:root {
-  /* ... */
+.Example {
+  line-height: 1.5;
+}
+
+.Example {
+  width: calc(0.444 * 100%);
 }
 
 .Example {
   font-size: calc(2.25 * 1em);
-  line-height: 1.5;
 }
 ```
 
@@ -67,7 +95,3 @@ See the [PostCSS usage docs] docs for more examples.
 ## Inspiration
 
 This plugin is inspired by [postcss-modular-scale] and [postcss-vertical-rhythm]. The goal is to provide a way to use modular scale values as if they were native CSS units.
-
-## Todo
-
-- Allow customization of the `msu` unit name.

--- a/dist/index.js
+++ b/dist/index.js
@@ -44,6 +44,20 @@ function plugin() {
       if (parentSelector === ':root' && propKey) {
         msOptions[propKey] = decl.value.split(' ');
       }
+
+      if (parentSelector === ':root' && /^--modular-scale$/.test(decl.prop)) {
+        var _ref4 = decl.value.match(/^((?:\d+[\.|\/])?\d+)(\s(?:\s?\d*\.?\d+)+)?$/) || [];
+
+        var _ref5 = _slicedToArray(_ref4, 3);
+
+        var ratios = _ref5[1];
+        var bases = _ref5[2];
+        // TODO: need to support <ratio> type (e.g. 4/3)
+
+        ratios = ratios.split(' ');
+        bases = bases.split(' ');
+        msOptions = { ratios: ratios, bases: bases };
+      }
     });
 
     /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,7 +14,23 @@ var _modularScale = require('modular-scale');
 
 var _modularScale2 = _interopRequireDefault(_modularScale);
 
+var _ramda = require('ramda');
+
+var _ramda2 = _interopRequireDefault(_ramda);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Pattern to match values for the `--modular-scale` property
+ *
+ * - Matches <number> ratios: 1.618
+ * - Matches <ratio> ratios: 4/3
+ * - Matches ratios followed by one <integer> base: 1.618 1
+ * - Matches ratios followed by many <integer> bases: 1.618 1 2
+ */
+
+var CONFIG_VALUE_PATTERN = /^((?:\d+[\.|\/])?\d+)(\s(?:\s?\d*\.?\d+)+)?$/;
+var CONFIG_PROPERTY_PATTERN = /^--modular-scale$/;
 
 function plugin() {
   var _ref = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
@@ -22,50 +38,79 @@ function plugin() {
   var _ref$name = _ref.name;
   var name = _ref$name === undefined ? 'msu' : _ref$name;
 
-  return function (css) {
-    var patterns = [new RegExp('^--' + name + '-(\\w+)'), new RegExp('-?\\d+' + name + '\\b', 'g')];
-    var msOptions = {};
-    var ms;
+  var isRootSelector = _ramda2.default.propEq('selector', ':root');
+  var msOptions = {};
+  var ms;
 
+  /**
+   * --msu-bases, --msu-ratios
+   */
+
+  function setScaleOptionLegacy(decl) {
+    var propPattern = new RegExp('^--' + name + '-(\\w+)');
+
+    var _match = (0, _ramda.match)(propPattern, decl.prop);
+
+    var _match2 = _slicedToArray(_match, 2);
+
+    var propKey = _match2[1];
+
+    if (propKey) msOptions[propKey] = decl.value.split(' ');
+  }
+
+  /**
+   * --modular-scale
+   */
+
+  function setScaleOption(decl) {
+    var _match3 = (0, _ramda.match)(CONFIG_VALUE_PATTERN, decl.value);
+
+    var _match4 = _slicedToArray(_match3, 3);
+
+    var ratios = _match4[1];
+    var bases = _match4[2];
+    // TODO: need to support <ratio> type (e.g. 4/3)
+
+    msOptions.ratios = ratios.split(' ');
+    if (bases) msOptions.bases = bases.split(' ');
+  }
+
+  return function (css, result) {
     /**
      * Extract ratios and bases from custom properties defined on `:root`.
      * If `--msu-ratios` or `--msu-bases` properties are found, their values
      * will be used to overwrite the default options for the modular scale.
+     *
+     * TODO: Deprecate support of these properties.
      */
-    css.walkDecls(function (decl) {
-      var parentSelector = decl.parent.selector;
 
-      var _ref2 = decl.prop.match(patterns[0]) || [];
-
-      var _ref3 = _slicedToArray(_ref2, 2);
-
-      var propKey = _ref3[1];
-
-      if (parentSelector === ':root' && propKey) {
-        msOptions[propKey] = decl.value.split(' ');
-      }
-
-      if (parentSelector === ':root' && /^--modular-scale$/.test(decl.prop)) {
-        var _ref4 = decl.value.match(/^((?:\d+[\.|\/])?\d+)(\s(?:\s?\d*\.?\d+)+)?$/) || [];
-
-        var _ref5 = _slicedToArray(_ref4, 3);
-
-        var ratios = _ref5[1];
-        var bases = _ref5[2];
-        // TODO: need to support <ratio> type (e.g. 4/3)
-
-        ratios = ratios.split(' ');
-        bases = bases.split(' ');
-        msOptions = { ratios: ratios, bases: bases };
+    css.walkDecls(new RegExp('^--' + name + '-(\\w+)'), function (decl) {
+      decl.warn(result, 'Setting options via ' + decl.prop + ' will be deprecated soon. Use the --modular-scale property instead.');
+      if (isRootSelector(decl.parent)) {
+        setScaleOptionLegacy(decl);
       }
     });
 
     /**
-     * Initialize the modular scale and replace any values using the `msu` unit
-     * with numbers resulting from it.
+     * Extract ratios and bases from a custom property defined on `:root`.
+     * If `--modular-scale` is found, its value will be used to overwrite
+     * the default options for the modular scale.
      */
+
+    css.walkDecls(CONFIG_PROPERTY_PATTERN, function (decl) {
+      if (isRootSelector(decl.parent)) {
+        setScaleOption(decl);
+      }
+    });
+
+    /**
+     * Initialize the modular scale; replace any CSS values using the supplied
+     * unit with calculated numbers resulting from the scale.
+     */
+
     ms = new _modularScale2.default(msOptions);
-    css.replaceValues(patterns[1], { fast: name }, function (str) {
+
+    css.replaceValues(new RegExp('-?\\d+' + name + '\\b', 'g'), { fast: name }, function (str) {
       return ms(parseInt(str, 10));
     });
   };

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,7 +17,13 @@ var _modularScale2 = _interopRequireDefault(_modularScale);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function plugin() {
+  var _ref = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+  var _ref$name = _ref.name;
+  var name = _ref$name === undefined ? 'msu' : _ref$name;
+
   return function (css) {
+    var patterns = [new RegExp('^--' + name + '-(\\w+)'), new RegExp('-?\\d+' + name + '\\b', 'g')];
     var msOptions = {};
     var ms;
 
@@ -29,11 +35,11 @@ function plugin() {
     css.walkDecls(function (decl) {
       var parentSelector = decl.parent.selector;
 
-      var _ref = decl.prop.match(/^--msu-(\w+)/) || [];
+      var _ref2 = decl.prop.match(patterns[0]) || [];
 
-      var _ref2 = _slicedToArray(_ref, 2);
+      var _ref3 = _slicedToArray(_ref2, 2);
 
-      var propKey = _ref2[1];
+      var propKey = _ref3[1];
 
       if (parentSelector === ':root' && propKey) {
         msOptions[propKey] = decl.value.split(' ');
@@ -45,7 +51,7 @@ function plugin() {
      * with numbers resulting from it.
      */
     ms = new _modularScale2.default(msOptions);
-    css.replaceValues(/-?\d+msu\b/g, { fast: 'msu' }, function (str) {
+    css.replaceValues(patterns[1], { fast: name }, function (str) {
       return ms(parseInt(str, 10));
     });
   };

--- a/dist/index.js
+++ b/dist/index.js
@@ -32,6 +32,16 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var CONFIG_VALUE_PATTERN = /^((?:\d+[\.|\/])?\d+)(\s(?:\s?\d*\.?\d+)+)?$/;
 var CONFIG_PROPERTY_PATTERN = /^--modular-scale$/;
 
+var splitOnSpace = (0, _ramda.split)(' ');
+var splitOnSlash = (0, _ramda.split)('/');
+var ratioToDecimal = (0, _ramda.pipe)(splitOnSlash, (0, _ramda.map)(function (n) {
+  return parseInt(n, 10);
+}), (0, _ramda.apply)(_ramda.divide), (0, _ramda.curry)(function (n) {
+  return n.toPrecision(4);
+}), (0, _ramda.curry)(function (n) {
+  return parseFloat(n);
+}));
+
 function plugin() {
   var _ref = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
 
@@ -55,7 +65,9 @@ function plugin() {
 
     var propKey = _match2[1];
 
-    if (propKey) msOptions[propKey] = decl.value.split(' ');
+    if (propKey) {
+      msOptions[propKey] = splitOnSpace(decl.value);
+    }
   }
 
   /**
@@ -68,11 +80,15 @@ function plugin() {
     var _match4 = _slicedToArray(_match3, 3);
 
     var ratios = _match4[1];
-    var bases = _match4[2];
-    // TODO: need to support <ratio> type (e.g. 4/3)
+    var _match4$ = _match4[2];
+    var bases = _match4$ === undefined ? '1' : _match4$;
 
-    msOptions.ratios = ratios.split(' ');
-    if (bases) msOptions.bases = bases.split(' ');
+    if ((0, _ramda.contains)('/', ratios)) {
+      ratios = (0, _ramda.toString)(ratioToDecimal(ratios));
+    }
+    bases = splitOnSpace(bases);
+    ratios = splitOnSpace(ratios);
+    msOptions = { bases: bases, ratios: ratios };
   }
 
   return function (css, result) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "main": "dist/index.js",
   "dependencies": {
     "modular-scale": "^4.4.1",
-    "postcss": "^5.0.13"
+    "postcss": "^5.0.13",
+    "ramda": "^0.19.1"
   },
   "devDependencies": {
     "ava": "^0.9.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,44 +1,84 @@
 import postcss from 'postcss'
 import ModularScale from 'modular-scale'
+import R, { match } from 'ramda'
+
+/**
+ * Pattern to match values for the `--modular-scale` property
+ *
+ * - Matches <number> ratios: 1.618
+ * - Matches <ratio> ratios: 4/3
+ * - Matches ratios followed by one <integer> base: 1.618 1
+ * - Matches ratios followed by many <integer> bases: 1.618 1 2
+ */
+
+const CONFIG_VALUE_PATTERN = /^((?:\d+[\.|\/])?\d+)(\s(?:\s?\d*\.?\d+)+)?$/
+const CONFIG_PROPERTY_PATTERN = /^--modular-scale$/
 
 function plugin ({ name = 'msu' } = {}) {
-  return css => {
-    var patterns = [
-      new RegExp(`^--${name}-(\\w+)`),
-      new RegExp(`-?\\d+${name}\\b`, 'g')
-    ]
-    var msOptions = {}
-    var ms
+  var isRootSelector = R.propEq('selector', ':root')
+  var msOptions = {}
+  var ms
 
+  /**
+   * --msu-bases, --msu-ratios
+   */
+
+  function setScaleOptionLegacy (decl) {
+    var propPattern = new RegExp(`^--${name}-(\\w+)`)
+    var [, propKey] = match(propPattern, decl.prop)
+    if (propKey) msOptions[propKey] = decl.value.split(' ')
+  }
+
+  /**
+   * --modular-scale
+   */
+
+  function setScaleOption (decl) {
+    let [, ratios, bases] = match(CONFIG_VALUE_PATTERN, decl.value)
+    // TODO: need to support <ratio> type (e.g. 4/3)
+    msOptions.ratios = ratios.split(' ')
+    if (bases) msOptions.bases = bases.split(' ')
+  }
+
+  return (css, result) => {
     /**
      * Extract ratios and bases from custom properties defined on `:root`.
      * If `--msu-ratios` or `--msu-bases` properties are found, their values
      * will be used to overwrite the default options for the modular scale.
+     *
+     * TODO: Deprecate support of these properties.
      */
-    css.walkDecls(decl => {
-      var parentSelector = decl.parent.selector
-      var [, propKey] = decl.prop.match(patterns[0]) || []
 
-      if (parentSelector === ':root' && propKey) {
-        msOptions[propKey] = decl.value.split(' ')
-      }
-    
-      if (parentSelector === ':root' && /^--modular-scale$/.test(decl.prop)) {
-        let [, ratios, bases] = decl.value.match(/^((?:\d+[\.|\/])?\d+)(\s(?:\s?\d*\.?\d+)+)?$/) || []
-        // TODO: need to support <ratio> type (e.g. 4/3)
-        ratios = ratios.split(' ')
-        bases = bases.split(' ')
-        msOptions = { ratios, bases }
+    css.walkDecls(new RegExp(`^--${name}-(\\w+)`), decl => {
+      decl.warn(result,
+        `Setting options via ${decl.prop} will be deprecated soon. Use the --modular-scale property instead.`
+      )
+      if (isRootSelector(decl.parent)) {
+        setScaleOptionLegacy(decl)
       }
     })
 
     /**
-     * Initialize the modular scale and replace any values using the `msu` unit
-     * with numbers resulting from it.
+     * Extract ratios and bases from a custom property defined on `:root`.
+     * If `--modular-scale` is found, its value will be used to overwrite
+     * the default options for the modular scale.
      */
+
+    css.walkDecls(CONFIG_PROPERTY_PATTERN, decl => {
+      if (isRootSelector(decl.parent)) {
+        setScaleOption(decl)
+      }
+    })
+
+    /**
+     * Initialize the modular scale; replace any CSS values using the supplied
+     * unit with calculated numbers resulting from the scale.
+     */
+
     ms = new ModularScale(msOptions)
+
     css.replaceValues(
-      patterns[1],
+      new RegExp(`-?\\d+${name}\\b`, 'g'),
       { fast: name },
       str => ms(parseInt(str, 10))
     )

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,12 @@
 import postcss from 'postcss'
 import ModularScale from 'modular-scale'
 
-function plugin () {
+function plugin ({ name = 'msu' } = {}) {
   return css => {
+    var patterns = [
+      new RegExp(`^--${name}-(\\w+)`),
+      new RegExp(`-?\\d+${name}\\b`, 'g')
+    ]
     var msOptions = {}
     var ms
 
@@ -13,7 +17,7 @@ function plugin () {
      */
     css.walkDecls(decl => {
       var parentSelector = decl.parent.selector
-      var [, propKey] = decl.prop.match(/^--msu-(\w+)/) || []
+      var [, propKey] = decl.prop.match(patterns[0]) || []
 
       if (parentSelector === ':root' && propKey) {
         msOptions[propKey] = decl.value.split(' ')
@@ -26,8 +30,8 @@ function plugin () {
      */
     ms = new ModularScale(msOptions)
     css.replaceValues(
-      /-?\d+msu\b/g,
-      { fast: 'msu' },
+      patterns[1],
+      { fast: name },
       str => ms(parseInt(str, 10))
     )
   }

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,14 @@ function plugin ({ name = 'msu' } = {}) {
       if (parentSelector === ':root' && propKey) {
         msOptions[propKey] = decl.value.split(' ')
       }
+    
+      if (parentSelector === ':root' && /^--modular-scale$/.test(decl.prop)) {
+        let [, ratios, bases] = decl.value.match(/^((?:\d+[\.|\/])?\d+)(\s(?:\s?\d*\.?\d+)+)?$/) || []
+        // TODO: need to support <ratio> type (e.g. 4/3)
+        ratios = ratios.split(' ')
+        bases = bases.split(' ')
+        msOptions = { ratios, bases }
+      }
     })
 
     /**

--- a/test/calc-out.css
+++ b/test/calc-out.css
@@ -1,5 +1,5 @@
 :root {
-  --msu-ratios: 1.5;
+  --modular-scale: 1.5;
 }
 
 example {

--- a/test/customName-in.css
+++ b/test/customName-in.css
@@ -1,5 +1,5 @@
 :root {
-  --mods-ratios: 1.5;
+  --modular-scale: 1.5;
 }
 
 example {

--- a/test/customName-in.css
+++ b/test/customName-in.css
@@ -1,0 +1,7 @@
+:root {
+  --mods-ratios: 1.5;
+}
+
+example {
+  value: -1mods 0mods 1mods calc(1mods * 1em);
+}

--- a/test/customName-out.css
+++ b/test/customName-out.css
@@ -1,0 +1,7 @@
+:root {
+  --mods-ratios: 1.5;
+}
+
+example {
+  value: 0.667 1 1.5 calc(1.5 * 1em);
+}

--- a/test/customName-out.css
+++ b/test/customName-out.css
@@ -1,5 +1,5 @@
 :root {
-  --mods-ratios: 1.5;
+  --modular-scale: 1.5;
 }
 
 example {

--- a/test/docsExample-in.css
+++ b/test/docsExample-in.css
@@ -1,0 +1,15 @@
+:root {
+  --modular-scale: 1.5;
+}
+
+.Example {
+  line-height: 1msu;
+}
+
+.Example {
+  width: calc(-2msu * 100%);
+}
+
+.Example {
+  font-size: calc(2msu * 1em);
+}

--- a/test/docsExample-out.css
+++ b/test/docsExample-out.css
@@ -1,0 +1,15 @@
+:root {
+  --modular-scale: 1.5;
+}
+
+.Example {
+  line-height: 1.5;
+}
+
+.Example {
+  width: calc(0.444 * 100%);
+}
+
+.Example {
+  font-size: calc(2.25 * 1em);
+}

--- a/test/legacy-in.css
+++ b/test/legacy-in.css
@@ -1,5 +1,5 @@
 :root {
-  --modular-scale: 1.5;
+  --msu-ratios: 1.3;
 }
 
 example {

--- a/test/legacy-out.css
+++ b/test/legacy-out.css
@@ -1,0 +1,7 @@
+:root {
+  --msu-ratios: 1.3;
+}
+
+example {
+  value: calc(1.3 * 1rem);
+}

--- a/test/multiple-in.css
+++ b/test/multiple-in.css
@@ -1,6 +1,5 @@
 :root {
-  --msu-bases: 1 1.5;
-  --msu-ratios: 2;
+  --modular-scale: 2 1 1.5;
 }
 
 example {

--- a/test/multiple-out.css
+++ b/test/multiple-out.css
@@ -1,6 +1,5 @@
 :root {
-  --msu-bases: 1 1.5;
-  --msu-ratios: 2;
+  --modular-scale: 2 1 1.5;
 }
 
 example {

--- a/test/supplied-in.css
+++ b/test/supplied-in.css
@@ -1,5 +1,6 @@
 :root {
   --msu-ratios: 1.5;
+  --modular-scale: 1.22 1;
 }
 
 example {

--- a/test/supplied-in.css
+++ b/test/supplied-in.css
@@ -1,5 +1,4 @@
 :root {
-  --msu-ratios: 1.5;
   --modular-scale: 1.22 1;
 }
 

--- a/test/supplied-in.css
+++ b/test/supplied-in.css
@@ -1,5 +1,6 @@
 :root {
   --modular-scale: 1.22 1;
+  --modular-scale: 4/3 1;
 }
 
 example {

--- a/test/supplied-out.css
+++ b/test/supplied-out.css
@@ -1,5 +1,4 @@
 :root {
-  --msu-ratios: 1.5;
   --modular-scale: 1.22 1;
 }
 

--- a/test/supplied-out.css
+++ b/test/supplied-out.css
@@ -1,7 +1,8 @@
 :root {
   --msu-ratios: 1.5;
+  --modular-scale: 1.22 1;
 }
 
 example {
-  value: 1.5;
+  value: 1.22;
 }

--- a/test/supplied-out.css
+++ b/test/supplied-out.css
@@ -1,7 +1,8 @@
 :root {
   --modular-scale: 1.22 1;
+  --modular-scale: 4/3 1;
 }
 
 example {
-  value: 1.22;
+  value: 1.333;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -3,16 +3,16 @@ import plugin from '../'
 import postcss from 'postcss'
 import test from 'ava'
 
-function run(t, input, output, opts = {}) {
+function run (t, input, output, opts = {}, strict = true) {
   return postcss([plugin(opts)])
     .process(input)
     .then(result => {
       t.same(result.css, output)
-      t.same(result.warnings().length, 0)
+      if (strict) t.same(result.warnings().length, 0)
     })
 }
 
-function readFile(path) {
+function readFile (path) {
   return fs.readFileSync(path, 'utf8')
 }
 
@@ -50,4 +50,10 @@ test('Works with a custom unit name', t => {
   var input = readFile('./customName-in.css')
   var expected = readFile('./customName-out.css')
   return run(t, input, expected, { name: 'mods' })
+})
+
+test('Supports legacy config properties', t => {
+  var input = readFile('./legacy-in.css')
+  var expected = readFile('./legacy-out.css')
+  return run(t, input, expected, {}, false)
 })

--- a/test/test.js
+++ b/test/test.js
@@ -45,3 +45,9 @@ test('Ignores invalid unit name', t => {
   var expected = readFile('./invalid-out.css')
   return run(t, input, expected)
 })
+
+test('Works with a custom unit name', t => {
+  var input = readFile('./customName-in.css')
+  var expected = readFile('./customName-out.css')
+  return run(t, input, expected, { name: 'mods' })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,12 @@ test('Works with a custom unit name', t => {
   return run(t, input, expected, { name: 'mods' })
 })
 
+test('Does what the docs show for example', t => {
+  var input = readFile('./docsExample-in.css')
+  var expected = readFile('./docsExample-out.css')
+  return run(t, input, expected)
+})
+
 test('Supports legacy config properties', t => {
   var input = readFile('./legacy-in.css')
   var expected = readFile('./legacy-out.css')


### PR DESCRIPTION
This change affects how custom properties are used to configure the underlaying modular scale.

Currently, this is handled by two distinct properties: `--msu-ratios` and `--msu-bases`. This change deprecates those in favor of a single property, `--modular-scale`, that accepts values for both the ratio and base(s). 

The docs have been updated to reflect this change. The old values are still supported for now, but with a PostCSS warning.
