### PR TITLE
Fix: Add option to specify rounding precision

### DIFF
--- a/src/ModularScale.js
+++ b/src/ModularScale.js
@@ -1,7 +1,10 @@
 import {
   all,
+  invoker,
   map,
+  max,
   memoize,
+  min,
   multiply,
   nth,
   pipe,
@@ -13,13 +16,17 @@ import {
   isAboveZero,
   pow,
   sortUp,
-  toFixedFloat,
+  toFloat,
   unnestSort
 } from './utils'
 
+const toValidPrecision = pipe(max(0), min(20))
+
 export default class ModularScale {
-  constructor ({ ratio = 1.618, bases = [1] } = {}) {
+  constructor ({ ratio = 1.618, bases = [1], precision = 3 } = {}) {
     const calc = pow(ratio)
+    const toFixed = invoker(1, 'toFixed')(toValidPrecision(precision))
+    const toFixedFloat = pipe(toFixed, toFloat)
 
     if (!isAboveOne(ratio)) {
       throw new TypeError('"ratio" must be a number greater than 1.')

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function plugin ({ name = 'msu', precision = 3 } = {}) {
   const valuePattern = new RegExp(`-?\\d+${name}\\b`, 'g')
 
   return (css, result) => {
-    const msOptions = { precision }
+    var msOptions
     var ms
 
     /**
@@ -64,7 +64,7 @@ function plugin ({ name = 'msu', precision = 3 } = {}) {
         )
 
         ratio = Ratios[matchingKey] || ratio
-        Object.assign(msOptions, evolve({
+        msOptions = evolve({
           /**
            * If `ratio` appears as a fraction string:
            * convert the fraction string to a float,
@@ -79,8 +79,9 @@ function plugin ({ name = 'msu', precision = 3 } = {}) {
           bases: ifElse(length, toFloats, () => [1])
         }, {
           ratio,
-          bases
-        }))
+          bases,
+          precision
+        })
       }
     })
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,11 +42,11 @@ const Ratios = {
   DOUBLE_OCTAVE: 4
 }
 
-function plugin ({ name = 'msu' } = {}) {
+function plugin ({ name = 'msu', precision = 3 } = {}) {
   const valuePattern = new RegExp(`-?\\d+${name}\\b`, 'g')
 
   return (css, result) => {
-    var msOptions
+    const msOptions = { precision }
     var ms
 
     /**
@@ -64,7 +64,7 @@ function plugin ({ name = 'msu' } = {}) {
         )
 
         ratio = Ratios[matchingKey] || ratio
-        msOptions = evolve({
+        Object.assign(msOptions, evolve({
           /**
            * If `ratio` appears as a fraction string:
            * convert the fraction string to a float,
@@ -80,7 +80,7 @@ function plugin ({ name = 'msu' } = {}) {
         }, {
           ratio,
           bases
-        })
+        }))
       }
     })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,6 @@ import {
   curry,
   divide,
   gt,
-  invoker,
   is,
   map,
   pipe,
@@ -22,8 +21,6 @@ export const toInt = curry(parseInt)(__, 10)
 export const toInts = map(toInt)
 export const toFloat = curry(parseFloat)
 export const toFloats = map(toFloat)
-export const toFixed = invoker(1, 'toFixed')(3)
-export const toFixedFloat = pipe(toFixed, toFloat)
 export const toLowerWords = pipe(toLower, replace(/[\W_]+/g, ''))
 export const sortUp = sort((a, b) => a - b)
 export const hasSlash = contains('/')

--- a/test/customPrec-in.css
+++ b/test/customPrec-in.css
@@ -1,0 +1,7 @@
+:root {
+  --modular-scale: 1.5;
+}
+
+example {
+  value: 5msu;
+}

--- a/test/customPrec-out.css
+++ b/test/customPrec-out.css
@@ -1,0 +1,7 @@
+:root {
+  --modular-scale: 1.5;
+}
+
+example {
+  value: 7.5938;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,12 @@ test('ModularScale supplied ratio and multiple bases', t => {
   t.same(ms(2), 1.5)
 })
 
+test('ModularScale supplied precision', t => {
+  var ms = new ModularScale({ ratio: 1.5, precision: 4 })
+  t.plan(1)
+  t.same(ms(5), 7.5938)
+})
+
 test('ModularScale errors with bad ratio', t => {
   t.plan(2)
   t.throws(
@@ -116,6 +122,12 @@ test('Works with a custom unit name', t => {
   var input = readFile('./customName-in.css')
   var expected = readFile('./customName-out.css')
   return run(t, input, expected, { name: 'mods' })
+})
+
+test('Works with precision override', t => {
+  var input = readFile('./customPrec-in.css')
+  var expected = readFile('./customPrec-out.css')
+  return run(t, input, expected, { precision: 4 })
 })
 
 test('Does what the docs show for example', t => {


### PR DESCRIPTION
This adds support for `precision` to be supplied as a plugin option.
